### PR TITLE
PAYLAPMEXT-123, PAYLAPMEXT-155 + Sonar

### DIFF
--- a/external.gradle
+++ b/external.gradle
@@ -4,6 +4,9 @@ repositories {
     maven {
         url "http://192.168.4.78:8081/repository/maven-releases"
     }
+    maven {
+        url "http://192.168.4.78:8081/repository/maven-mixed"
+    }
 }
 
 publishing {

--- a/src/main/java/com/payline/payment/docapost/bean/rest/response/mandate/WSMandateDTOResponse.java
+++ b/src/main/java/com/payline/payment/docapost/bean/rest/response/mandate/WSMandateDTOResponse.java
@@ -94,7 +94,7 @@ public class WSMandateDTOResponse extends AbstractXmlResponse {
     //******************************************************************************************************************
     //***** BUILDER
     public static final class Builder {
-        public static WSMandateDTOResponse fromXml(String xmlContent) {
+        public WSMandateDTOResponse fromXml(String xmlContent) {
             return (WSMandateDTOResponse) parse(WSMandateDTOResponse.class, xmlContent);
         }
     }

--- a/src/main/java/com/payline/payment/docapost/service/AbstractRefundHttpService.java
+++ b/src/main/java/com/payline/payment/docapost/service/AbstractRefundHttpService.java
@@ -97,7 +97,7 @@ public abstract class AbstractRefundHttpService<T extends RefundRequest> {
                         return this.processResponseFailure(response);
                     }
                 default:
-                    logger.error("The HTTP response or its body is null and should not be");
+                    logger.error(HTTP_NULL_RESPONSE_ERROR_MESSAGE);
                     return buildRefundResponseFailure(DEFAULT_ERROR_CODE, FailureCause.INTERNAL_ERROR);
             }
 

--- a/src/main/java/com/payline/payment/docapost/service/AbstractResetHttpService.java
+++ b/src/main/java/com/payline/payment/docapost/service/AbstractResetHttpService.java
@@ -97,7 +97,7 @@ public abstract class AbstractResetHttpService<T extends ResetRequest> {
                         return this.processResponseFailure(response);
                     }
                 default:
-                    logger.error("The HTTP response or its body is null and should not be");
+                    logger.error(HTTP_NULL_RESPONSE_ERROR_MESSAGE);
                     return buildResetResponseFailure(DEFAULT_ERROR_CODE, FailureCause.INTERNAL_ERROR);
             }
 

--- a/src/main/java/com/payline/payment/docapost/service/impl/RefundServiceImpl.java
+++ b/src/main/java/com/payline/payment/docapost/service/impl/RefundServiceImpl.java
@@ -79,27 +79,19 @@ public class RefundServiceImpl extends AbstractRefundHttpService<RefundRequest> 
 
         AbstractXmlResponse sctOrderCreateXmlResponse = getSctOrderCreateResponse(response.getContent().trim());
 
-        if (sctOrderCreateXmlResponse != null) {
+        if (sctOrderCreateXmlResponse != null && sctOrderCreateXmlResponse.isResultOk()) {
+            LOGGER.info("SctOrderCreateXmlResponse AbstractXmlResponse instance of WSCTOrderDTOResponse");
 
-            // Just in case but must be true
-            if (sctOrderCreateXmlResponse.isResultOk()) {
+            WSCTOrderDTOResponse sctOrderCreateResponse = (WSCTOrderDTOResponse) sctOrderCreateXmlResponse;
 
-                LOGGER.info("SctOrderCreateXmlResponse AbstractXmlResponse instance of WSCTOrderDTOResponse");
+            LOGGER.debug("SddOrderCreateResponse : {}", () -> sctOrderCreateResponse.toString());
 
-                WSCTOrderDTOResponse sctOrderCreateResponse = (WSCTOrderDTOResponse) sctOrderCreateXmlResponse;
-
-                LOGGER.debug("SddOrderCreateResponse : {}", sctOrderCreateResponse.toString());
-
-                return buildRefundResponseSuccess(sctOrderCreateResponse.getStatus(), sctOrderCreateResponse.getE2eId());
-
-            }
-
+            return buildRefundResponseSuccess(sctOrderCreateResponse.getStatus(), sctOrderCreateResponse.getE2eId());
         }
 
         // case : sctOrderCreateXmlResponse is null
         LOGGER.info("null sctOrderCreateXmlResponse");
         return buildRefundResponseFailure("XML RESPONSE PARSING FAILED", FailureCause.INVALID_DATA);
-
     }
 
     @Override
@@ -107,24 +99,17 @@ public class RefundServiceImpl extends AbstractRefundHttpService<RefundRequest> 
 
         AbstractXmlResponse sctOrderCreateXmlResponse = getSctOrderCreateResponse(response.getContent().trim());
 
-        if (sctOrderCreateXmlResponse != null) {
+        if (sctOrderCreateXmlResponse != null && !sctOrderCreateXmlResponse.isResultOk()) {
+            LOGGER.info("SctOrderCreateXmlResponse AbstractXmlResponse instance of XmlErrorResponse");
 
-            // Just in case but must be true
-            if (!sctOrderCreateXmlResponse.isResultOk()) {
+            XmlErrorResponse xmlErrorResponse = (XmlErrorResponse) sctOrderCreateXmlResponse;
 
-                LOGGER.info("SctOrderCreateXmlResponse AbstractXmlResponse instance of XmlErrorResponse");
+            LOGGER.debug("SddOrderCreateResponse : {}", () -> xmlErrorResponse.toString());
 
-                XmlErrorResponse xmlErrorResponse = (XmlErrorResponse) sctOrderCreateXmlResponse;
+            // Retrieve the partner error type
+            WSRequestResultEnum wsRequestResult = WSRequestResultEnum.fromDocapostErrorCode(xmlErrorResponse.getException().getCode());
 
-                LOGGER.debug("SddOrderCreateResponse : {}", xmlErrorResponse.toString());
-
-                // Retrieve the partner error type
-                WSRequestResultEnum wsRequestResult = WSRequestResultEnum.fromDocapostErrorCode(xmlErrorResponse.getException().getCode());
-
-                return buildPaymentResponseFailure(wsRequestResult);
-
-            }
-
+            return buildPaymentResponseFailure(wsRequestResult);
         }
 
         // case : sctOrderCreateXmlResponse is null

--- a/src/main/java/com/payline/payment/docapost/service/impl/ResetServiceImpl.java
+++ b/src/main/java/com/payline/payment/docapost/service/impl/ResetServiceImpl.java
@@ -79,27 +79,19 @@ public class ResetServiceImpl extends AbstractResetHttpService<ResetRequest> imp
 
         AbstractXmlResponse orderCancelXmlResponse = getOrderCancelResponse(response.getContent().trim());
 
-        if (orderCancelXmlResponse != null) {
+        if (orderCancelXmlResponse != null && orderCancelXmlResponse.isResultOk()) {
+            LOGGER.info("OrderCancelXmlResponse AbstractXmlResponse instance of WSCTOrderDTOResponse");
 
-            // Just in case but must be true
-            if (orderCancelXmlResponse.isResultOk()) {
+            WSDDOrderDTOResponse orderCancelResponse = (WSDDOrderDTOResponse) orderCancelXmlResponse;
 
-                LOGGER.info("OrderCancelXmlResponse AbstractXmlResponse instance of WSCTOrderDTOResponse");
+            LOGGER.debug("OrderCancelResponse : {}", () -> orderCancelResponse.toString());
 
-                WSDDOrderDTOResponse orderCancelResponse = (WSDDOrderDTOResponse) orderCancelXmlResponse;
-
-                LOGGER.debug("OrderCancelResponse : {}", orderCancelResponse.toString());
-
-                return buildResetResponseSuccess(orderCancelResponse.getStatus(), orderCancelResponse.getE2eId());
-
-            }
-
+            return buildResetResponseSuccess(orderCancelResponse.getStatus(), orderCancelResponse.getE2eId());
         }
 
         // case : orderCancelXmlResponse is null
         LOGGER.info("null orderCancelXmlResponse");
         return buildResetResponseFailure("XML RESPONSE PARSING FAILED", FailureCause.INVALID_DATA);
-
     }
 
     @Override
@@ -107,24 +99,17 @@ public class ResetServiceImpl extends AbstractResetHttpService<ResetRequest> imp
 
         AbstractXmlResponse orderCancelXmlResponse = getOrderCancelResponse(response.getContent().trim());
 
-        if (orderCancelXmlResponse != null) {
+        if (orderCancelXmlResponse != null && !orderCancelXmlResponse.isResultOk()) {
+            LOGGER.info("OrderCancelXmlResponse AbstractXmlResponse instance of XmlErrorResponse");
 
-            // Just in case but must be true
-            if (!orderCancelXmlResponse.isResultOk()) {
+            XmlErrorResponse xmlErrorResponse = (XmlErrorResponse) orderCancelXmlResponse;
 
-                LOGGER.info("OrderCancelXmlResponse AbstractXmlResponse instance of XmlErrorResponse");
+            LOGGER.debug("OrderCancelResponse : {}", () -> xmlErrorResponse.toString());
 
-                XmlErrorResponse xmlErrorResponse = (XmlErrorResponse) orderCancelXmlResponse;
+            // Retrieve the partner error type
+            WSRequestResultEnum wsRequestResult = WSRequestResultEnum.fromDocapostErrorCode(xmlErrorResponse.getException().getCode());
 
-                LOGGER.debug("OrderCancelResponse : {}", xmlErrorResponse.toString());
-
-                // Retrieve the partner error type
-                WSRequestResultEnum wsRequestResult = WSRequestResultEnum.fromDocapostErrorCode(xmlErrorResponse.getException().getCode());
-
-                return buildResetResponseFailure(wsRequestResult);
-
-            }
-
+            return buildResetResponseFailure(wsRequestResult);
         }
 
         // case : orderCancelXmlResponse is null

--- a/src/main/java/com/payline/payment/docapost/utils/DocapostConstants.java
+++ b/src/main/java/com/payline/payment/docapost/utils/DocapostConstants.java
@@ -103,6 +103,9 @@ public class DocapostConstants {
     public static final String CONTEXT_DATA_STEP = "step";
     public static final String CONTEXT_DATA_STEP_IBAN_PHONE = "IBAN_PHONE";
     public static final String CONTEXT_DATA_STEP_OTP = "OTP";
+    public static final String CONTEXT_DATA_BIC = "bic";
+    public static final String CONTEXT_DATA_COUNTRY_CODE = "countryCode";
+    public static final String CONTEXT_DATA_IBAN = "iban";
     public static final String CONTEXT_DATA_MANDATE_RUM = "mandateRum";
     public static final String CONTEXT_DATA_TRANSACTION_ID = "transactionId";
     public static final String CONTEXT_DATA_SIGNATURE_ID = "signatureId";
@@ -121,7 +124,6 @@ public class DocapostConstants {
     public static final String NOFIELDFORM_BUTTON_DESCRIPTION = "form.nofield.button.description";
 
     //Data used by the IbanForm Object
-    public static final String IBAN_TEXT = "form.iban.phone.text.setIban";
     public static final String IBAN_KEY = "formDebtorIban";
     public static final boolean IBAN_REQUIRED = false;
     public static final String IBAN_REQUIRED_ERROR_MESSAGE = "form.iban.phone.text.ibanRequiredErrorMessage";

--- a/src/main/java/com/payline/payment/docapost/utils/DocapostFormUtils.java
+++ b/src/main/java/com/payline/payment/docapost/utils/DocapostFormUtils.java
@@ -38,25 +38,13 @@ public class DocapostFormUtils {
     public static CustomForm createEmptyIbanPhonePaymentForm(Locale locale) {
         I18nService i18n = I18nService.getInstance();
 
-        PaymentFormDisplayFieldText inputIban = PaymentFormDisplayFieldText
-                .PaymentFormDisplayFieldTextBuilder
-                .aPaymentFormDisplayFieldText()
-                .withContent(i18n.getMessage(OTP_IBAN_PHONE_TEXT_SET_IBAN, locale))
-                .build();
-
         PaymentFormInputFieldIban ibanForm = PaymentFormInputFieldIban
                 .IbanFieldBuilder
                 .anIbanField()
                 .withKey(IBAN_KEY)
-                .withLabel(i18n.getMessage(IBAN_TEXT, locale))
+                .withLabel(i18n.getMessage(OTP_IBAN_PHONE_TEXT_SET_IBAN, locale))
                 .withRequired(IBAN_REQUIRED)
                 .withRequiredErrorMessage(i18n.getMessage(IBAN_REQUIRED_ERROR_MESSAGE, locale))
-                .build();
-
-        PaymentFormDisplayFieldText inputPhone = PaymentFormDisplayFieldText
-                .PaymentFormDisplayFieldTextBuilder
-                .aPaymentFormDisplayFieldText()
-                .withContent(i18n.getMessage(OTP_IBAN_PHONE_TEXT_SET_PHONE, locale))
                 .build();
 
         PaymentFormInputFieldText phoneForm = PaymentFormInputFieldText
@@ -82,9 +70,7 @@ public class DocapostFormUtils {
                 .build();
 
         List<PaymentFormField> customFields = new ArrayList<>();
-        customFields.add(inputIban);
         customFields.add(ibanForm);
-        customFields.add(inputPhone);
         customFields.add(phoneForm);
         customFields.add(inputPhoneInfo);
 
@@ -112,26 +98,6 @@ public class DocapostFormUtils {
         Locale locale = request.getLocale();
         I18nService i18n = I18nService.getInstance();
         String phone = request.getPaymentFormContext().getPaymentFormParameter().get(FORM_FIELD_PHONE);
-        ConfigEnvironment env = PluginUtils.getEnvironnement(request);
-
-
-//        PaymentFormDisplayFieldText downloadMandateText = PaymentFormDisplayFieldText
-//                .PaymentFormDisplayFieldTextBuilder
-//                .aPaymentFormDisplayFieldText()
-//                .withContent(i18n.getMessage(OTP_FORM_TEXT_DOWNLOAD_MANDATE, locale))
-//                .build();
-
-//        PaymentFormDisplayFieldLink downloadMandateLink = PaymentFormDisplayFieldLink
-//                .PaymentFormDisplayFieldLinkBuilder
-//                .aPaymentFormDisplayFieldLink()
-//                .withUrl(getDownloadMandateLinkUrl(
-//                        env,
-//                        sendOtpRequest.getCreditorId(),
-//                        docapostLocalParam.getMandateRum()
-//                ))
-//                .withName(i18n.getMessage(OTP_FORM_LINK_DOWNLOAD_MANDATE, locale))
-//                .withTitle(i18n.getMessage(OTP_FORM_LINK_DOWNLOAD_MANDATE, locale))
-//                .build();
 
         PaymentFormDisplayFieldText otpText = PaymentFormDisplayFieldText
                 .PaymentFormDisplayFieldTextBuilder
@@ -161,20 +127,6 @@ public class DocapostFormUtils {
                 .withValue(OTP_FORM_VALUE)
                 .build();
 
-        //Resend otp pas disponible pour le moment
-//        PaymentFormDisplayFieldLink resendOtpLink = PaymentFormDisplayFieldLink
-//                .PaymentFormDisplayFieldLinkBuilder
-//                .aPaymentFormDisplayFieldLink()
-//                .withUrl(getResendOtpLinkUrl(
-//                        env,
-//                        sendOtpRequest.getCreditorId(),
-//                        docapostLocalParam.getMandateRum(),
-//                        docapostLocalParam.getTransactionId()
-//                ))
-//                .withName(i18n.getMessage(OTP_FORM_TEXT_RESEND_OTP, locale))
-//                .withTitle(i18n.getMessage(OTP_FORM_TEXT_RESEND_OTP, locale))
-//                .build();
-
         PaymentFormInputFieldCheckbox acceptCondition = PaymentFormInputFieldCheckbox
                 .PaymentFormFieldCheckboxBuilder
                 .aPaymentFormFieldCheckbox()
@@ -186,26 +138,11 @@ public class DocapostFormUtils {
                 .withSecured(ACCEPT_CONDITION_SECURED)
                 .build();
 
-//        PaymentFormInputFieldCheckbox saveMandate = PaymentFormInputFieldCheckbox
-//                .PaymentFormFieldCheckboxBuilder
-//                .aPaymentFormFieldCheckbox()
-//                .withRequired(SAVE_MANDATE_REQUIRED)
-//                .withLabel(i18n.getMessage(OTP_FORM_CHECKBOX_SAVE_MANDATE, locale))
-//                .withRequiredErrorMessage(i18n.getMessage(SAVE_MANDATE_REQUIRED_ERROR_MESSAGE, locale))
-//                .withKey(SAVE_MANDATE_KEY)
-//                .withPrechecked(SAVE_MANDATE_PRECHECKED)
-//                .withSecured(SAVE_MANDATE_SECURED)
-//                .build();
-
-
         List<PaymentFormField> customFields = new ArrayList<>();
-//        customFields.add(downloadMandateText);
-//        customFields.add(downloadMandateLink);
         customFields.add(otpText);
         customFields.add(setOtpText);
         customFields.add(otpForm);
         customFields.add(acceptCondition);
-//        customFields.add(saveMandate);
 
         return CustomForm
                 .builder()
@@ -214,8 +151,6 @@ public class DocapostFormUtils {
                 .withButtonText(i18n.getMessage(CUSTOMFORM_TEXT_SIGN, locale))
                 .withDisplayButton(true)
                 .build();
-
-
     }
 
 

--- a/src/main/java/com/payline/payment/docapost/utils/DocapostLocalParam.java
+++ b/src/main/java/com/payline/payment/docapost/utils/DocapostLocalParam.java
@@ -1,5 +1,6 @@
 package com.payline.payment.docapost.utils;
 
+import com.payline.payment.docapost.bean.rest.response.mandate.WSMandateDTOResponse;
 import com.payline.pmapi.bean.payment.request.PaymentRequest;
 
 import static com.payline.payment.docapost.utils.DocapostConstants.*;
@@ -11,6 +12,9 @@ public class DocapostLocalParam {
     private String signatureId;
     private Boolean signatureSuccess;
     private String orderStatus;
+    private String mandateCreateBic;
+    private String mandateCreateCountryCode;
+    private String mandateCreateIban;
 
     private DocapostLocalParam() {
     }
@@ -64,6 +68,30 @@ public class DocapostLocalParam {
 
     public void setOrderStatus(String orderStatus) {
         this.orderStatus = orderStatus;
+    }
+
+    public String getMandateCreateBic() {
+        return mandateCreateBic;
+    }
+
+    public void setMandateCreateBic(String mandateCreateBic) {
+        this.mandateCreateBic = mandateCreateBic;
+    }
+
+    public String getMandateCreateCountryCode() {
+        return mandateCreateCountryCode;
+    }
+
+    public void setMandateCreateCountryCode(String mandateCreateCountryCode) {
+        this.mandateCreateCountryCode = mandateCreateCountryCode;
+    }
+
+    public String getMandateCreateIban() {
+        return mandateCreateIban;
+    }
+
+    public void setMandateCreateIban(String mandateCreateIban) {
+        this.mandateCreateIban = mandateCreateIban;
     }
 
     public void restoreFromPaylineRequest(PaymentRequest request) {

--- a/src/test/java/com/payline/payment/docapost/service/impl/PaymentServiceStep02Test.java
+++ b/src/test/java/com/payline/payment/docapost/service/impl/PaymentServiceStep02Test.java
@@ -376,23 +376,23 @@ public class PaymentServiceStep02Test {
 
         PaymentResponseFormUpdated paymentResponseFormUpdated = (PaymentResponseFormUpdated) paymentResponse;
 
-        // PaymentResponseFormUpdated.requestContext.requestData must be not null, not empty and must contains 4 data :
+        // PaymentResponseFormUpdated.requestContext.requestData must be not null, not empty and must contain :
         // - the 3 data from the docapostLocalParam (mandateRum, transactionId and signatureId)
         // - the next PaymentService step (OTP)
+        // - the elements from the mandate creation response : IBAN, BIC and countryCode
         Map<String, String> requestData = paymentResponseFormUpdated.getRequestContext().getRequestData();
 
         Assert.assertNotNull(requestData);
-        Assert.assertTrue(!requestData.isEmpty() && requestData.size() == 4);
+        Assert.assertEquals( 6, requestData.size() );
         Assert.assertEquals("expMandateRum", requestData.get(CONTEXT_DATA_MANDATE_RUM));
         Assert.assertEquals("expTransactionId", requestData.get(CONTEXT_DATA_TRANSACTION_ID));
         Assert.assertEquals("expSignatureId", requestData.get(CONTEXT_DATA_SIGNATURE_ID));
         Assert.assertEquals(CONTEXT_DATA_STEP_OTP, requestData.get(CONTEXT_DATA_STEP));
 
-        // PaymentResponseFormUpdated.requestContext.sensitiveRequestData must be not null and empty
+        // PaymentResponseFormUpdated.requestContext.sensitiveRequestData must be not null
         Map<String, String> sensitiveRequestData = paymentResponseFormUpdated.getRequestContext().getSensitiveRequestData();
-
         Assert.assertNotNull(sensitiveRequestData);
-        Assert.assertTrue(sensitiveRequestData.isEmpty());
+        Assert.assertEquals( 1, sensitiveRequestData.size() );
 
         PaymentFormConfigurationResponse paymentFormConfigurationResponse = paymentResponseFormUpdated.getPaymentFormConfigurationResponse();
 


### PR DESCRIPTION
* PAYLAPMEXT-123 : renvoi des données de paiement dans la `PaymentResponseSuccess` (fin du step 3)
* PAYLAPMEXT-155 : suppression des messages en doublon
* Correction de plusieurs problèmes graves remontés par Sonar